### PR TITLE
Added other start executor schema options for Azure Functions.

### DIFF
--- a/packages/func/src/executors/start/executor.ts
+++ b/packages/func/src/executors/start/executor.ts
@@ -9,7 +9,48 @@ const executor: Executor<StartExecutorSchema> = async (options, context) => {
   if (success) {
     const cwd = context.workspace?.projects[context.projectName].root;
 
-    execSync(`func start --port ${options.port}`, {
+    const {
+      port,
+      cors,
+      corsCredentials,
+      timeout,
+      useHttps,
+      cert,
+      password,
+      languageWorker,
+      noBuild,
+      enableAuth,
+      functions,
+      verbose,
+      dotnetIsolatedDebug,
+      enableJsonOutput,
+      jsonOutputFile,
+    } = options;
+
+    const args = [
+      { flag: '--port', value: port },
+      { flag: '--cors', value: cors },
+      { flag: '--cors-credentials', value: corsCredentials },
+      { flag: '--timeout', value: timeout },
+      { flag: '--useHttps', value: useHttps },
+      { flag: '--cert', value: cert, condition: useHttps },
+      { flag: '--password', value: password, condition: cert },
+      { flag: '--language-worker', value: languageWorker },
+      { flag: '--no-build', value: noBuild },
+      { flag: '--enableAuth', value: enableAuth },
+      { flag: '--functions', value: functions },
+      { flag: '--verbose', value: verbose },
+      { flag: '--dotnet-isolated-debug', dotnetIsolatedDebug },
+      { flag: '--enable-json-output', value: enableJsonOutput },
+      { flag: '--json-output-file', value: jsonOutputFile, condition: enableJsonOutput },
+    ];
+
+    const command = args
+      .filter(arg => arg.value && (!arg.condition || arg.condition))
+      .map(arg => `${arg.flag} ${arg.value}`)
+      .join(' ');
+
+    execSync(`func start ${command}`, {
       cwd,
       stdio: 'inherit',
     });

--- a/packages/func/src/executors/start/executor.ts
+++ b/packages/func/src/executors/start/executor.ts
@@ -1,7 +1,7 @@
-import { StartExecutorSchema } from './schema';
 import { Executor } from '@nrwl/devkit';
-import { build } from '../common/utils';
 import { execSync } from 'child_process';
+import { build } from '../common/utils';
+import { StartExecutorSchema } from './schema';
 
 const executor: Executor<StartExecutorSchema> = async (options, context) => {
   const success = build(context);
@@ -9,48 +9,7 @@ const executor: Executor<StartExecutorSchema> = async (options, context) => {
   if (success) {
     const cwd = context.workspace?.projects[context.projectName].root;
 
-    const {
-      port,
-      cors,
-      corsCredentials,
-      timeout,
-      useHttps,
-      cert,
-      password,
-      languageWorker,
-      noBuild,
-      enableAuth,
-      functions,
-      verbose,
-      dotnetIsolatedDebug,
-      enableJsonOutput,
-      jsonOutputFile,
-    } = options;
-
-    const args = [
-      { flag: '--port', value: port },
-      { flag: '--cors', value: cors },
-      { flag: '--cors-credentials', value: corsCredentials },
-      { flag: '--timeout', value: timeout },
-      { flag: '--useHttps', value: useHttps },
-      { flag: '--cert', value: cert, condition: useHttps },
-      { flag: '--password', value: password, condition: cert },
-      { flag: '--language-worker', value: languageWorker },
-      { flag: '--no-build', value: noBuild },
-      { flag: '--enableAuth', value: enableAuth },
-      { flag: '--functions', value: functions },
-      { flag: '--verbose', value: verbose },
-      { flag: '--dotnet-isolated-debug', dotnetIsolatedDebug },
-      { flag: '--enable-json-output', value: enableJsonOutput },
-      { flag: '--json-output-file', value: jsonOutputFile, condition: enableJsonOutput },
-    ];
-
-    const command = args
-      .filter(arg => arg.value && (!arg.condition || arg.condition))
-      .map(arg => `${arg.flag} ${arg.value}`)
-      .join(' ');
-
-    execSync(`func start ${command}`, {
+    execSync(`func start ${options.additionalFlags}`, {
       cwd,
       stdio: 'inherit',
     });

--- a/packages/func/src/executors/start/executor.ts
+++ b/packages/func/src/executors/start/executor.ts
@@ -7,9 +7,16 @@ const executor: Executor<StartExecutorSchema> = async (options, context) => {
   const success = build(context);
 
   if (success) {
-    const cwd = context.workspace?.projects[context.projectName].root;
+    const { workspace, projectName, isVerbose, target } = context;
+    const cwd = workspace?.projects[projectName].root;
 
-    execSync(`func start ${options.additionalFlags}`, {
+    const { port, additionalFlags } = options;
+    const command = `func start --port ${port} ${additionalFlags}`;
+    if (isVerbose) {
+      console.log(`Running ${target.executor} command: ${command}.`);
+    }
+
+    execSync(command, {
       cwd,
       stdio: 'inherit',
     });

--- a/packages/func/src/executors/start/schema.d.ts
+++ b/packages/func/src/executors/start/schema.d.ts
@@ -1,17 +1,3 @@
 export interface StartExecutorSchema {
-  port: number;
-  cors: string;
-  corsCredentials: boolean;
-  timeout: number;
-  useHttps: boolean;
-  cert: string;
-  password: string;
-  languageWorker: string;
-  noBuild: boolean;
-  enableAuth: boolean;
-  functions: string;
-  verbose: boolean;
-  dotnetIsolatedDebug: boolean;
-  enableJsonOutput: boolean;
-  jsonOutputFile: string;
+  additionalFlags: string;
 } // eslint-disable-line

--- a/packages/func/src/executors/start/schema.d.ts
+++ b/packages/func/src/executors/start/schema.d.ts
@@ -1,3 +1,4 @@
 export interface StartExecutorSchema {
+  port: number;
   additionalFlags: string;
 } // eslint-disable-line

--- a/packages/func/src/executors/start/schema.d.ts
+++ b/packages/func/src/executors/start/schema.d.ts
@@ -1,3 +1,17 @@
 export interface StartExecutorSchema {
   port: number;
+  cors: string;
+  corsCredentials: boolean;
+  timeout: number;
+  useHttps: boolean;
+  cert: string;
+  password: string;
+  languageWorker: string;
+  noBuild: boolean;
+  enableAuth: boolean;
+  functions: string;
+  verbose: boolean;
+  dotnetIsolatedDebug: boolean;
+  enableJsonOutput: boolean;
+  jsonOutputFile: string;
 } // eslint-disable-line

--- a/packages/func/src/executors/start/schema.json
+++ b/packages/func/src/executors/start/schema.json
@@ -6,95 +6,10 @@
   "description": "",
   "type": "object",
   "properties": {
-    "port": {
-      "type": "number",
-      "description": "The port to start the function app on",
-      "default": 7071,
-      "x-prompt": "What is the port to start the function app on?"
-    },
-    "cors": {
+    "additionalFlags": {
       "type": "string",
-      "description": "A comma separated list of CORS origins with no spaces. Example: https://functions.azure.com,https://functions-staging.azure.com. To allow all, use \"*\" and remove all other origins from the list.",
-      "default": "",
-      "x-prompt": "Add CORS origins to use for the function app?"
-    },
-    "corsCredentials": {
-      "type": "boolean",
-      "description": "Allow cross-origin authenticated requests (i.e. cookies and the Authentication header).",
-      "default": false,
-      "x-prompt": "Enable CORS access-control-allow-credentials?"
-    },
-    "timeout": {
-      "type": "number",
-      "description": "Timeout for the functions host to start in seconds. Default: 20 seconds.",
-      "default": 20,
-      "x-prompt": "Enable CORS access-control-allow-credentials?"
-    },
-    "useHttps": {
-      "type": "boolean",
-      "description": "Bind to https://localhost:{port} rather than http://localhost:{port}. By default it creates and trusts a certificate.",
-      "default": false,
-      "x-prompt": "Generate a certificate and use https?"
-    },
-    "cert": {
-      "type": "string",
-      "description": "for use with --useHttps. The path to a pfx file that contains a private key.",
-      "default": "",
-      "x-prompt": "Use a custom private key for your certificate?"
-    },
-    "password": {
-      "type": "string",
-      "description": "to use with --cert. Either the password, or a file that contains the password for the pfx file",
-      "default": "",
-      "x-prompt": "Provide the password or path to the password file for the pfx."
-    },
-    "languageWorker": {
-      "type": "string",
-      "description": "Arguments to configure the language worker.",
-      "default": "",
-      "x-prompt": "Provide any arguments to configure the language worker."
-    },
-    "noBuild": {
-      "type": "boolean",
-      "description": "Do no build current project before running. For dotnet projects only. Default is set to false.",
-      "default": false,
-      "x-prompt": "Skip building dotnet projects before running?"
-    },
-    "enableAuth": {
-      "type": "boolean",
-      "description": "Enable full authentication handling pipeline.",
-      "default": false,
-      "x-prompt": "Would you like to enable the full authentication handling pipeline?"
-    },
-    "functions": {
-      "type": "string",
-      "description": "A space seperated list of functions to load.",
-      "default": "",
-      "x-prompt": "Load specific functions?"
-    },
-    "verbose": {
-      "type": "boolean",
-      "description": "When false, hides system logs other than warnings and errors.",
-      "default": false,
-      "x-prompt": "Would you like to show system logs in addition to warnings and errors?"
-    },
-    "dotnetIsolatedDebug": {
-      "type": "boolean",
-      "description": "When specified, set to true, pauses the .NET Worker process until a debugger is attached.",
-      "default": false,
-      "x-prompt": "Would you like to pauses the .NET Worker process until a debugger is attached?"
-    },
-    "enableJsonOutput": {
-      "type": "boolean",
-      "description": "Signals to Core Tools and other components that JSON line output console logs, when applicable, should be emitted.",
-      "default": false,
-      "x-prompt": "Would you like to enable, when applicable, emitting JSON line output console logs?"
-    },
-    "jsonOutputFile": {
-      "type": "string",
-      "description": "If provided, a path to the file that will be used to write the output when using --enable-json-output.",
-      "default": "",
-      "x-prompt": "Provide a path a path to the file that will be used to write the output when using --enable-json-output."
+      "description": "Additional flags to pass to the func start command. (port, cors, etc.)",
+      "x-prompt": "Are there any additional flags to start the Azure Functions runtime?"
     }
   },
   "required": []

--- a/packages/func/src/executors/start/schema.json
+++ b/packages/func/src/executors/start/schema.json
@@ -6,6 +6,12 @@
   "description": "",
   "type": "object",
   "properties": {
+    "port": {
+      "type": "number",
+      "description": "The port to start the function app on",
+      "default": 7071,
+      "x-prompt": "What is the port to start the function app on?"
+    },
     "additionalFlags": {
       "type": "string",
       "description": "Additional flags to pass to the func start command. (port, cors, etc.)",

--- a/packages/func/src/executors/start/schema.json
+++ b/packages/func/src/executors/start/schema.json
@@ -11,6 +11,90 @@
       "description": "The port to start the function app on",
       "default": 7071,
       "x-prompt": "What is the port to start the function app on?"
+    },
+    "cors": {
+      "type": "string",
+      "description": "A comma separated list of CORS origins with no spaces. Example: https://functions.azure.com,https://functions-staging.azure.com. To allow all, use \"*\" and remove all other origins from the list.",
+      "default": "",
+      "x-prompt": "Add CORS origins to use for the function app?"
+    },
+    "corsCredentials": {
+      "type": "boolean",
+      "description": "Allow cross-origin authenticated requests (i.e. cookies and the Authentication header).",
+      "default": false,
+      "x-prompt": "Enable CORS access-control-allow-credentials?"
+    },
+    "timeout": {
+      "type": "number",
+      "description": "Timeout for the functions host to start in seconds. Default: 20 seconds.",
+      "default": 20,
+      "x-prompt": "Enable CORS access-control-allow-credentials?"
+    },
+    "useHttps": {
+      "type": "boolean",
+      "description": "Bind to https://localhost:{port} rather than http://localhost:{port}. By default it creates and trusts a certificate.",
+      "default": false,
+      "x-prompt": "Generate a certificate and use https?"
+    },
+    "cert": {
+      "type": "string",
+      "description": "for use with --useHttps. The path to a pfx file that contains a private key.",
+      "default": "",
+      "x-prompt": "Use a custom private key for your certificate?"
+    },
+    "password": {
+      "type": "string",
+      "description": "to use with --cert. Either the password, or a file that contains the password for the pfx file",
+      "default": "",
+      "x-prompt": "Provide the password or path to the password file for the pfx."
+    },
+    "languageWorker": {
+      "type": "string",
+      "description": "Arguments to configure the language worker.",
+      "default": "",
+      "x-prompt": "Provide any arguments to configure the language worker."
+    },
+    "noBuild": {
+      "type": "boolean",
+      "description": "Do no build current project before running. For dotnet projects only. Default is set to false.",
+      "default": false,
+      "x-prompt": "Skip building dotnet projects before running?"
+    },
+    "enableAuth": {
+      "type": "boolean",
+      "description": "Enable full authentication handling pipeline.",
+      "default": false,
+      "x-prompt": "Would you like to enable the full authentication handling pipeline?"
+    },
+    "functions": {
+      "type": "string",
+      "description": "A space seperated list of functions to load.",
+      "default": "",
+      "x-prompt": "Load specific functions?"
+    },
+    "verbose": {
+      "type": "boolean",
+      "description": "When false, hides system logs other than warnings and errors.",
+      "default": false,
+      "x-prompt": "Would you like to show system logs in addition to warnings and errors?"
+    },
+    "dotnetIsolatedDebug": {
+      "type": "boolean",
+      "description": "When specified, set to true, pauses the .NET Worker process until a debugger is attached.",
+      "default": false,
+      "x-prompt": "Would you like to pauses the .NET Worker process until a debugger is attached?"
+    },
+    "enableJsonOutput": {
+      "type": "boolean",
+      "description": "Signals to Core Tools and other components that JSON line output console logs, when applicable, should be emitted.",
+      "default": false,
+      "x-prompt": "Would you like to enable, when applicable, emitting JSON line output console logs?"
+    },
+    "jsonOutputFile": {
+      "type": "string",
+      "description": "If provided, a path to the file that will be used to write the output when using --enable-json-output.",
+      "default": "",
+      "x-prompt": "Provide a path a path to the file that will be used to write the output when using --enable-json-output."
     }
   },
   "required": []


### PR DESCRIPTION
Hey again @AlexPshul ,
I added some more, useful, executor flags for the Azure Functions runtime.
I have a need for a few of these for development and testing purposes. (cors, https...)
I wasn't able to test every combination of argument, hopefully you have some time to spare to test otherwise I can in the future.
Thanks!