### PR TITLE
Added support for function on subfolder for init generator

### DIFF
--- a/e2e/func-e2e/tests/func.spec.ts
+++ b/e2e/func-e2e/tests/func.spec.ts
@@ -2,6 +2,7 @@ import { ensureNxProject, readJson, runNxCommandAsync, uniq, updateFile } from '
 import { CompilerOptions } from 'typescript';
 
 describe('Project initialization and build', () => {
+  const TEST_TIMEOUT = 120000;
   // Setting up individual workspaces per
   // test can cause e2e runs to take a long time.
   // For this reason, we recommend each suite only
@@ -24,7 +25,7 @@ describe('Project initialization and build', () => {
     const buildResult = await runNxCommandAsync(`build ${project}`);
 
     expect(buildResult.stdout).toContain(`Done compiling TypeScript files for project "${project}"`);
-  }, 120000);
+  }, TEST_TIMEOUT);
 
   it('should init & build a workspace with a functions app and a function', async () => {
     const project = uniq('func');
@@ -35,7 +36,7 @@ describe('Project initialization and build', () => {
     const buildResult = await runNxCommandAsync(`build ${project}`);
 
     expect(buildResult.stdout).toContain(`Done compiling TypeScript files for project "${project}"`);
-  }, 120000);
+  }, TEST_TIMEOUT);
 
   it('should init & build a workspace with a js lib functions app and a function', async () => {
     const project = uniq('func');
@@ -68,7 +69,7 @@ describe('Project initialization and build', () => {
     const buildResult = await runNxCommandAsync(`build ${project}`);
 
     expect(buildResult.stdout).toContain(`Done compiling TypeScript files for project "${project}"`);
-  }, 120000);
+  }, TEST_TIMEOUT);
 
   it('Use strict mode', async () => {
     const project = uniq('func');
@@ -79,7 +80,7 @@ describe('Project initialization and build', () => {
 
     expect(tsConfig.compilerOptions.strict).toBe(true);
     expect(tsBuildConfig.compilerOptions.strict).toBe(true);
-  }, 120000);
+  }, TEST_TIMEOUT);
 
   it('Use no strict mode', async () => {
     const project = uniq('func');
@@ -90,7 +91,7 @@ describe('Project initialization and build', () => {
 
     expect(tsConfig.compilerOptions.strict).toBe(false);
     expect(tsBuildConfig.compilerOptions.strict).toBe(false);
-  }, 120000);
+  }, TEST_TIMEOUT);
 
   it('should init & build and empty workspace with a functions app (V4)', async () => {
     const project = uniq('func');
@@ -98,7 +99,7 @@ describe('Project initialization and build', () => {
     const buildResult = await runNxCommandAsync(`build ${project}`);
 
     expect(buildResult.stdout).toContain(`Done compiling TypeScript files for project "${project}"`);
-  }, 120000);
+  }, TEST_TIMEOUT);
 
   it('should init & build a workspace with a functions app and a function (V4)', async () => {
     const project = uniq('func');
@@ -109,7 +110,7 @@ describe('Project initialization and build', () => {
     const buildResult = await runNxCommandAsync(`build ${project}`);
 
     expect(buildResult.stdout).toContain(`Done compiling TypeScript files for project "${project}"`);
-  }, 120000);
+  }, TEST_TIMEOUT);
 
   it('should init & build a workspace with a js lib functions app and a function (V4)', async () => {
     const project = uniq('func');
@@ -144,7 +145,7 @@ describe('Project initialization and build', () => {
     const buildResult = await runNxCommandAsync(`build ${project}`);
 
     expect(buildResult.stdout).toContain(`Done compiling TypeScript files for project "${project}"`);
-  }, 120000);
+  }, TEST_TIMEOUT);
 
   it('Use strict mode (V4)', async () => {
     const project = uniq('func');
@@ -155,7 +156,7 @@ describe('Project initialization and build', () => {
 
     expect(tsConfig.compilerOptions.strict).toBe(true);
     expect(tsBuildConfig.compilerOptions.strict).toBe(true);
-  }, 120000);
+  }, TEST_TIMEOUT);
 
   it('Use no strict mode (V4)', async () => {
     const project = uniq('func');
@@ -166,5 +167,5 @@ describe('Project initialization and build', () => {
 
     expect(tsConfig.compilerOptions.strict).toBe(false);
     expect(tsBuildConfig.compilerOptions.strict).toBe(false);
-  }, 120000);
+  }, TEST_TIMEOUT);
 });

--- a/packages/func/src/generators/common/utils.ts
+++ b/packages/func/src/generators/common/utils.ts
@@ -1,4 +1,4 @@
-import { Tree } from '@nx/devkit';
+import { Tree, names } from '@nx/devkit';
 import { execSync } from 'child_process';
 import fs from 'fs';
 import os from 'os';
@@ -7,7 +7,8 @@ import path from 'path';
 const getEnvTempDir = () => process.env.RUNNER_TEMP || os.tmpdir(); // This supports not only local dev but also GitHub Actions
 
 export const createTempFolderWithInit = (tempAppName: string, v4: boolean) => {
-  const tempFolder = fs.mkdtempSync(path.posix.join(getEnvTempDir(), `func-${tempAppName}-`));
+  const tempName = names(tempAppName).fileName.split('/')
+  const tempFolder = fs.mkdtempSync(path.posix.join(getEnvTempDir(),`func-${tempName.pop()}-`));
 
   try {
     execSync(`func init ${tempAppName} --worker-runtime node --language typescript ${v4 ? '--model V4' : ''}`, {

--- a/packages/func/src/generators/init/tests/main-v3.spec.ts
+++ b/packages/func/src/generators/init/tests/main-v3.spec.ts
@@ -12,8 +12,20 @@ jest.mock('@nx/devkit', () => {
   };
 });
 
-describe('Check files (v3)', () => {
-  const projectName = 'HelloWorld';
+describe.each([
+  {
+    name: 'HelloWorld',
+    path: 'apps/hello-world',
+    sublevelFromRoot: 2
+  },
+  {
+    name: 'core/HelloWorld',
+    path: 'apps/core/hello-world',
+    sublevelFromRoot: 3
+  }
+])
+('Check files (v3)', (testArgs: { name: string, path: string, sublevelFromRoot: number }) => {
+  const projectName = testArgs.name;
   let appTree: Tree;
   const options: InitGeneratorSchema = { name: projectName, strict: true, silent: true, v4: false };
 
@@ -24,7 +36,7 @@ describe('Check files (v3)', () => {
   });
 
   it('Folder name', () => {
-    expect(appTree.exists('apps/hello-world')).toBeTruthy();
+    expect(appTree.exists(testArgs.path)).toBeTruthy();
   });
 
   it('Project config', () => {
@@ -59,11 +71,11 @@ describe('Check files (v3)', () => {
   });
 
   it('Workspace TS config file', () => {
-    const tsconfig = appTree.read('apps/hello-world/tsconfig.json');
+    const tsconfig = appTree.read(`${testArgs.path}/tsconfig.json`);
     expect(tsconfig).toBeDefined();
 
     const tsconfigObj = JSON.parse(tsconfig?.toString() || '{}');
-    expect(tsconfigObj).toHaveProperty('extends', '../../tsconfig.base.json');
+    expect(tsconfigObj).toHaveProperty('extends', `${'../'.repeat(testArgs.sublevelFromRoot)}tsconfig.base.json`);
     expect(tsconfigObj).toHaveProperty('compilerOptions.module', 'commonjs');
     expect(tsconfigObj).toHaveProperty('compilerOptions.target', 'es6');
     expect(tsconfigObj).toHaveProperty('compilerOptions.sourceMap', true);
@@ -71,7 +83,7 @@ describe('Check files (v3)', () => {
   });
 
   it('Build TS config file', () => {
-    const tsconfig = appTree.read('apps/hello-world/tsconfig.build.json');
+    const tsconfig = appTree.read(`${testArgs.path}/tsconfig.build.json`);
     expect(tsconfig).toBeDefined();
 
     const tsconfigObj = JSON.parse(tsconfig?.toString() || '{}');
@@ -93,19 +105,19 @@ describe('Check files (v3)', () => {
   });
 
   it('Project eslint config file', () => {
-    const eslintConfig = appTree.read('apps/hello-world/.eslintrc.json');
+    const eslintConfig = appTree.read(`${testArgs.path}/.eslintrc.json`);
     expect(eslintConfig).toBeDefined();
 
     const eslintConfigObj = JSON.parse(eslintConfig?.toString() || '{}');
-    expect(eslintConfigObj).toHaveProperty('extends', '../../.eslintrc.json');
-    expect(eslintConfigObj.overrides[0]).toHaveProperty('parserOptions.project', ['apps/hello-world/tsconfig.*?.json']);
+    expect(eslintConfigObj).toHaveProperty('extends', `${'../'.repeat(testArgs.sublevelFromRoot)}.eslintrc.json`);
+    expect(eslintConfigObj.overrides[0]).toHaveProperty('parserOptions.project', [`${testArgs.path}/tsconfig.*?.json`]);
   });
 
   it('Auto generated files', () => {
-    expect(appTree.exists('apps/hello-world/package.json')).toBeTruthy();
-    expect(appTree.exists('apps/hello-world/host.json')).toBeTruthy();
-    expect(appTree.exists('apps/hello-world/local.settings.json')).toBeTruthy();
-    expect(appTree.exists('apps/hello-world/.funcignore')).toBeTruthy();
-    expect(appTree.exists('apps/hello-world/_registerPaths.ts')).toBeTruthy();
+    expect(appTree.exists(`${testArgs.path}/package.json`)).toBeTruthy();
+    expect(appTree.exists(`${testArgs.path}/host.json`)).toBeTruthy();
+    expect(appTree.exists(`${testArgs.path}/local.settings.json`)).toBeTruthy();
+    expect(appTree.exists(`${testArgs.path}/.funcignore`)).toBeTruthy();
+    expect(appTree.exists(`${testArgs.path}/_registerPaths.ts`)).toBeTruthy();
   });
 });

--- a/packages/func/src/generators/init/tests/main-v4.spec.ts
+++ b/packages/func/src/generators/init/tests/main-v4.spec.ts
@@ -12,8 +12,20 @@ jest.mock('@nx/devkit', () => {
   };
 });
 
-describe('Check files (v4)', () => {
-  const projectName = 'HelloWorld';
+describe.each([
+  {
+    name: 'HelloWorld',
+    path: 'apps/hello-world',
+    sublevelFromRoot: 2
+  },
+  {
+    name: 'core/HelloWorld',
+    path: 'apps/core/hello-world',
+    sublevelFromRoot: 3
+  }
+])
+('Check files (v4)', (testArgs: { name: string, path: string, sublevelFromRoot: number }) => {
+  const projectName = testArgs.name;
   let appTree: Tree;
   const options: InitGeneratorSchema = { name: projectName, strict: true, silent: true, v4: true };
 
@@ -24,7 +36,7 @@ describe('Check files (v4)', () => {
   }, 120000);
 
   it('Folder name', () => {
-    expect(appTree.exists('apps/hello-world')).toBeTruthy();
+    expect(appTree.exists(testArgs.path)).toBeTruthy();
   });
 
   it('Project config', () => {
@@ -59,11 +71,11 @@ describe('Check files (v4)', () => {
   });
 
   it('Workspace TS config file', () => {
-    const tsconfig = appTree.read('apps/hello-world/tsconfig.json');
+    const tsconfig = appTree.read(`${testArgs.path}/tsconfig.json`);
     expect(tsconfig).toBeDefined();
 
     const tsconfigObj = JSON.parse(tsconfig?.toString() || '{}');
-    expect(tsconfigObj).toHaveProperty('extends', '../../tsconfig.base.json');
+    expect(tsconfigObj).toHaveProperty('extends', `${'../'.repeat(testArgs.sublevelFromRoot)}tsconfig.base.json`);
     expect(tsconfigObj).toHaveProperty('compilerOptions.module', 'commonjs');
     expect(tsconfigObj).toHaveProperty('compilerOptions.target', 'es6');
     expect(tsconfigObj).toHaveProperty('compilerOptions.sourceMap', true);
@@ -71,7 +83,7 @@ describe('Check files (v4)', () => {
   });
 
   it('Build TS config file', () => {
-    const tsconfig = appTree.read('apps/hello-world/tsconfig.build.json');
+    const tsconfig = appTree.read(`${testArgs.path}/tsconfig.build.json`);
     expect(tsconfig).toBeDefined();
 
     const tsconfigObj = JSON.parse(tsconfig?.toString() || '{}');
@@ -93,24 +105,24 @@ describe('Check files (v4)', () => {
   });
 
   it('Project eslint config file', () => {
-    const eslintConfig = appTree.read('apps/hello-world/.eslintrc.json');
+    const eslintConfig = appTree.read(`${testArgs.path}/.eslintrc.json`);
     expect(eslintConfig).toBeDefined();
 
     const eslintConfigObj = JSON.parse(eslintConfig?.toString() || '{}');
-    expect(eslintConfigObj).toHaveProperty('extends', '../../.eslintrc.json');
-    expect(eslintConfigObj.overrides[0]).toHaveProperty('parserOptions.project', ['apps/hello-world/tsconfig.*?.json']);
+    expect(eslintConfigObj).toHaveProperty('extends', `${'../'.repeat(testArgs.sublevelFromRoot)}.eslintrc.json`);
+    expect(eslintConfigObj.overrides[0]).toHaveProperty('parserOptions.project', [`${testArgs.path}/tsconfig.*?.json`]);
   });
 
   it('Project package.json file', () => {
-    const packageJson = appTree.read('apps/hello-world/package.json');
+    const packageJson = appTree.read(`${testArgs.path}/package.json`);
     expect(packageJson).toBeDefined();
 
     const packageJsonObj = JSON.parse(packageJson?.toString() || '{}');
-    expect(packageJsonObj).toHaveProperty('main', 'dist/apps/hello-world/src/functions/*.js');
+    expect(packageJsonObj).toHaveProperty('main', `dist/${testArgs.path}/src/functions/*.js`);
   });
 
   it('Local settings file', () => {
-    const localSettings = appTree.read('apps/hello-world/local.settings.json');
+    const localSettings = appTree.read(`${testArgs.path}/local.settings.json`);
     expect(localSettings).toBeDefined();
 
     const localSettingsObj = JSON.parse(localSettings?.toString() || '{}');
@@ -118,8 +130,8 @@ describe('Check files (v4)', () => {
   });
 
   it('Auto generated files', () => {
-    expect(appTree.exists('apps/hello-world/host.json')).toBeTruthy();
-    expect(appTree.exists('apps/hello-world/.funcignore')).toBeTruthy();
-    expect(appTree.exists('apps/hello-world/_registerPaths.ts')).toBeTruthy();
+    expect(appTree.exists(`${testArgs.path}/host.json`)).toBeTruthy();
+    expect(appTree.exists(`${testArgs.path}/.funcignore`)).toBeTruthy();
+    expect(appTree.exists(`${testArgs.path}/_registerPaths.ts`)).toBeTruthy();
   });
 });


### PR DESCRIPTION
### Objective
I'm setting up a monorepo where some funcions are grouped in subfolders. This PR fixes the problem that happens when the temp folder is being created and there's a slash in the function name.

### Observations
Unit tests ran ok, but one of the e2e tests took longer than 120000 locally.