### PR TITLE
fix(func): exclude paths from tsconfig merge migration + v2.0.1

### DIFF
--- a/packages/func/package.json
+++ b/packages/func/package.json
@@ -2,7 +2,7 @@
   "name": "@nxazure/func",
   "author": "Alex Pshul",
   "description": "Nx plugin for Azure Functions to initialize, create, build, run and publish Azure Functions inside your NX workspace.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "main": "src/index.js",
   "repository": "https://github.com/AlexPshul/nxazure",
   "license": "MIT",

--- a/packages/func/src/migrations/update-2-0-0/merge-tsconfig-build.spec.ts
+++ b/packages/func/src/migrations/update-2-0-0/merge-tsconfig-build.spec.ts
@@ -67,6 +67,20 @@ describe('merge-tsconfig-build migration', () => {
     expect(tsconfig.compilerOptions.tsBuildInfoFile).toBeUndefined();
   });
 
+  it('should not copy paths from tsconfig.build.json', () => {
+    tree.write(`${projectRoot}/tsconfig.json`, JSON.stringify({ compilerOptions: { strict: true } }));
+    tree.write(
+      `${projectRoot}/tsconfig.build.json`,
+      JSON.stringify({ compilerOptions: { outDir: 'dist', paths: { '@my-app/*': ['src/*'] } } }),
+    );
+
+    mergeTsconfigBuild(tree);
+
+    const tsconfig = readJson(tree, `${projectRoot}/tsconfig.json`);
+    expect(tsconfig.compilerOptions.paths).toBeUndefined();
+    expect(tsconfig.compilerOptions.outDir).toBe('dist');
+  });
+
   it('should set outDir to dist if missing from both files', () => {
     tree.write(`${projectRoot}/tsconfig.json`, JSON.stringify({ compilerOptions: { strict: true } }));
 

--- a/packages/func/src/migrations/update-2-0-0/merge-tsconfig-build.ts
+++ b/packages/func/src/migrations/update-2-0-0/merge-tsconfig-build.ts
@@ -1,7 +1,7 @@
 import { getProjects, readJson, Tree, updateJson } from '@nx/devkit';
 import { color, FUNC_PACKAGE_NAME, GLOBAL_NAME } from '../../common';
 
-const buildManagedOptions = new Set(['noEmitOnError', 'rootDir', 'tsBuildInfoFile']);
+const buildManagedOptions = new Set(['noEmitOnError', 'rootDir', 'tsBuildInfoFile', 'paths']);
 const skippedTopLevelKeys = new Set(['extends', 'compilerOptions']);
 
 type TsConfig = {


### PR DESCRIPTION
## What

The `merge-tsconfig-build` migration (v2.0.0) was copying `compilerOptions.paths` from `tsconfig.build.json` into `tsconfig.json`. Since v2.0.0 removed path resolution support entirely (`_registerPaths.ts` + `tsconfig-paths` dependency), `paths` should not be carried over.

## Changes

- Added `'paths'` to the `buildManagedOptions` skip-set in `merge-tsconfig-build.ts`
- Added test case verifying `paths` are excluded from the merge
- Bumped version to `2.0.1`

## Release Notes (draft)

- **Bug fix**: The `merge-tsconfig-build` migration no longer copies `compilerOptions.paths` from `tsconfig.build.json` into `tsconfig.json`. This prevents stale path mappings from being left behind after migration, since path resolution was removed in v2.0.0.