### PR TITLE
Publish fix for PNPM workspaces

### DIFF
--- a/packages/func/src/executors/publish/executor.ts
+++ b/packages/func/src/executors/publish/executor.ts
@@ -12,7 +12,7 @@ const getInstallCommand = () => {
   const rawInstallCommand = getPackageManagerCommand().install;
 
   const packageManager = detectPackageManager();
-  return packageManager === 'pnpm' ? `${rawInstallCommand} --node-linker=hoisted` : rawInstallCommand;
+  return packageManager === 'pnpm' ? `${rawInstallCommand} --node-linker=hoisted -ignore-workspace` : rawInstallCommand;
 };
 
 const getConfiguredProjectRoot = (context: ExecutorContext) => {


### PR DESCRIPTION
After some extensive debugging I found out that the `getInstallCommand()` within the publish executor installs the packages, but because of the workspace file, it (re)installs them in the root of the monorepo. So our function app doesn't receive its own `node_modules` folder.

The executor was working successfully however. But, inspecting the package within Azure showed that no modules were present.